### PR TITLE
Fix relative vs absolute paths

### DIFF
--- a/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
+++ b/scg-system/src/main/java/io/telicent/core/SmartCacheGraph.java
@@ -95,7 +95,7 @@ public class SmartCacheGraph {
                         rdfConfigPath.deleteOnExit();
 
                         try (FileOutputStream out = new FileOutputStream(rdfConfigPath)) {
-                            configModel.write(out, "TTL");
+                            configModel.write(out, "TTL", new File(configPath).getAbsoluteFile().getParentFile().toURI().toString());
                             args[i + 1] = rdfConfigPath.getPath();
                         } catch (IOException e) {
                             log.error(e.getMessage());

--- a/scg-system/src/test/files/yaml/config-abac-multiple.ttl
+++ b/scg-system/src/test/files/yaml/config-abac-multiple.ttl
@@ -10,7 +10,7 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         ja:data   "src/test/files/yaml/data-and-labels.trig" .
 
 :abac-db  rdf:type        authz:DatasetAuthz;
-        authz:attributes  <file:/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl>;
+        authz:attributes  <file:src/test/files/yaml/attribute-store.ttl>;
         authz:cache       false;
         authz:dataset     :dataset-under .
 
@@ -26,7 +26,7 @@ PREFIX tdb2:   <http://jena.apache.org/2016/tdb#>
         fuseki:name      "ds-2" .
 
 :abac-db-2  rdf:type      authz:DatasetAuthz;
-        authz:attributes  <file:/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl>;
+        authz:attributes  <file:src/test/files/yaml/attribute-store.ttl>;
         authz:cache       false;
         authz:dataset     :dataset-under-2 .
 

--- a/scg-system/src/test/files/yaml/config-abac-multiple.yaml
+++ b/scg-system/src/test/files/yaml/config-abac-multiple.yaml
@@ -1,27 +1,30 @@
 version: "1.0"
 server:
   name: "Fuseki server simple"
+prefixes:
+  - prefix: "authz"
+    namespace: "http://telicent.io/security#"
 services:
   - name: "ds"
     endpoints:
-      - operation: query
+      - operation: authz:query
         settings:
       - name: "upload"
-        operation: upload
+        operation: authz:upload
     database:  "abac-db"
   - name: "ds-2"
     endpoints:
-      - operation: query
+      - operation: authz:query
         settings:
       - name: "upload"
-        operation: upload
+        operation: authz:upload
     database: "abac-db-2"
 
 databases:
   - name: "abac-db"
     dbtype: ABAC
     dataset: "dataset-under"
-    attributes: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl"
+    attributes: "attribute-store.ttl"
 
   - name: "dataset-under"
     dbtype: TIM
@@ -30,7 +33,7 @@ databases:
   - name: "abac-db-2"
     dbtype: ABAC
     dataset: "dataset-under-2"
-    attributes: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl"
+    attributes: "attribute-store.ttl"
 
   - name: "dataset-under-2"
     dbtype: TIM

--- a/scg-system/src/test/files/yaml/config-abac-tim.yaml
+++ b/scg-system/src/test/files/yaml/config-abac-tim.yaml
@@ -17,10 +17,10 @@ databases:
   - name: "abac-mem-db"
     dbtype: ABAC
     dataset: "dataset-under"
-    attributes: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl"
+    attributes: "attribute-store.ttl"
 
   - name: "dataset-under"
     dbtype: TIM
-    data: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/data-and-labels.trig"
+    data: "src/test/files/yaml/data-and-labels.trig"
     settings:
       'arq:queryTimeout': "100,100"

--- a/scg-system/src/test/files/yaml/config-connector-integration-test-1.yaml
+++ b/scg-system/src/test/files/yaml/config-connector-integration-test-1.yaml
@@ -29,12 +29,12 @@ connectors:
   - fuseki-service: "/ds"
     topic: "RDF0"
     bootstrap-servers: "localhost:9092"
-    state-file: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/Replay-RDF0-ds.state"
+    state-file: "target/Replay-RDF0-ds.state"
     replay-topic: true
   - fuseki-service: "/ds2"
     topic: "RDF0"
     bootstrap-servers: "localhost:9092"
-    state-file: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/Replay-RDF0-ds2.state"
+    state-file: "target/Replay-RDF0-ds2.state"
     replay-topic: true
 
 

--- a/scg-system/src/test/files/yaml/config-prefixes-1.yaml
+++ b/scg-system/src/test/files/yaml/config-prefixes-1.yaml
@@ -24,9 +24,9 @@ databases:
   - name: "abac-tdb2-db"
     dbtype: ABAC
     dataset: "dataset-under"
-    attributes: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl"
+    attributes: "attribute-store.ttl"
     labels-store: "target/labels"
 
   - name: "dataset-under"
     dbtype: TIM
-    data: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/data-and-labels.trig"
+    data: "src/test/files/yaml/data-and-labels.trig"

--- a/scg-system/src/test/files/yaml/config-prefixes-2.yaml
+++ b/scg-system/src/test/files/yaml/config-prefixes-2.yaml
@@ -24,7 +24,7 @@ databases:
   - name: "abac-tdb2-db"
     dbtype: ABAC
     dataset: "dataset-under"
-    attributes: "/Users/karolinakadzielawa/smart-cache-graph/scg-system/src/test/files/yaml/attribute-store.ttl"
+    attributes: "attribute-store.ttl"
     labels-store: "target/labels"
 
   - name: "dataset-under"


### PR DESCRIPTION
This commits fixes relative vs absolute paths by using the directory of the original YAML config file as the Base URI based to the `model.write()` call so that when Jena parses the generated RDF configuration it resolves the paths correctly.

YAML test cases are adjusted accordingly